### PR TITLE
Record of CRAN fixes, version 1.2

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,5 +1,11 @@
-.Rproj.user
-.Rhistory
-.RData
-.lvimrc
-.git
+^.*\.Rproj$
+^\.Rproj\.user$
+.travis.yml
+CHANGELOG.md
+^LICENSE\.md$
+^docker$
+^doc$
+^Meta$
+^vignettes\*.md$
+^vignettes\figure$
+^\.circleci$

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,20 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: rocker/verse:4.2.2
+    environment:
+            _R_CHECK_FORCE_SUGGESTS_: false
+    steps:
+      - checkout
+      - run:
+          name: Install package dependencies
+          command: R -e "devtools::install_deps(dep = TRUE)"
+      - run:
+          name: Build package
+          command: R CMD build .
+      - run:
+          name: Check package
+          command: R CMD check --no-manual *tar.gz
+      - store_test_results:
+          path: tmp/tests

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .Rproj.user
 .Rhistory
 .RData
-.lvimrc
+.Ruserdata
+Rook*.tar.gz
+Rook*Rcheck

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,10 +1,10 @@
 Package: Rook
 Type: Package
 Title: Rook - a web server interface for R
-Version: 1.1-1
-Date: 2014-10-20
-Author: Jeffrey Horner <jeffrey.horner@gmail.com>
-Maintainer: Jeffrey Horner <jeffrey.horner@gmail.com>
+Version: 1.2
+Date: 2022-Nov-03
+Author: Jeffrey Horner [aut], Evan Biederstedt [aut, cre]
+Maintainer: Evan Biederstedt <evan.biederstedt@gmail.com>
 Description: This package contains the Rook specification and
  convenience software for building and running Rook applications. To
  get started, be sure and read the 'Rook' help file first.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,12 +1,11 @@
 Package: Rook
 Type: Package
-Title: Rook - a Web Server Interface for R
+Title: HTTP Web Server for R
 Version: 1.2
-Date: 2022-Nov-03
+Date: 2022-11-03
 Author: Jeffrey Horner [aut], Evan Biederstedt [aut, cre]
 Maintainer: Evan Biederstedt <evan.biederstedt@gmail.com>
-Description: An HTTP web server for R. The documentation contains the Rook specification and details for building and running Rook applications. To
- get started, be sure and read the 'Rook' help file first.
+Description: An HTTP web server for R with a documented API to interface between R and the server. The documentation contains the Rook specification and details for building and running Rook applications. To get started, be sure and read the 'Rook' help file first.
 Depends: R (>= 2.13.0)
 Imports: utils, tools, methods, brew
 License: GPL-2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,12 +1,11 @@
 Package: Rook
 Type: Package
-Title: Rook - a web server interface for R
+Title: Rook - a Web Server Interface for R
 Version: 1.2
 Date: 2022-Nov-03
 Author: Jeffrey Horner [aut], Evan Biederstedt [aut, cre]
 Maintainer: Evan Biederstedt <evan.biederstedt@gmail.com>
-Description: This package contains the Rook specification and
- convenience software for building and running Rook applications. To
+Description: An HTTP web server for R. The documentation contains the Rook specification and details for building and running Rook applications. To
  get started, be sure and read the 'Rook' help file first.
 Depends: R (>= 2.13.0)
 Imports: utils, tools, methods, brew

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ Depends: R (>= 2.13.0)
 Imports: utils, tools, methods, brew
 License: GPL-2
 LazyLoad: yes
-URL: https://https://github.com/evanbiederstedt/rook
+URL: https://github.com/evanbiederstedt/rook
 BugReports: https://github.com/evanbiederstedt/rook/issues
 Author: Jeffrey Horner [aut], Evan Biederstedt [aut, cre]
 Maintainer: Evan Biederstedt <evan.biederstedt@gmail.com>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,12 +1,14 @@
 Package: Rook
-Type: Package
 Title: HTTP Web Server for R
 Version: 1.2
-Date: 2022-11-03
-Author: Jeffrey Horner [aut], Evan Biederstedt [aut, cre]
-Maintainer: Evan Biederstedt <evan.biederstedt@gmail.com>
+Date: 2022-11-05
 Description: An HTTP web server for R with a documented API to interface between R and the server. The documentation contains the Rook specification and details for building and running Rook applications. To get started, be sure and read the 'Rook' help file first.
+Encoding: UTF-8
 Depends: R (>= 2.13.0)
 Imports: utils, tools, methods, brew
 License: GPL-2
 LazyLoad: yes
+URL: https://https://github.com/evanbiederstedt/rook
+BugReports: https://github.com/evanbiederstedt/rook/issues
+Author: Jeffrey Horner [aut], Evan Biederstedt [aut, cre]
+Maintainer: Evan Biederstedt <evan.biederstedt@gmail.com>

--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
+[![<evanbiederstedt>](https://circleci.com/gh/evanbiederstedt/Rook.svg?style=svg)](https://app.circleci.com/pipelines/github/evanbiederstedt/Rook)
+[![CRAN status](https://www.r-pkg.org/badges/version/Rook)](https://cran.r-project.org/package=Rook)
+[![CRAN downloads](https://cranlogs.r-pkg.org/badges/Rook)](https://cran.r-project.org/package=Rook)
+
+
+**NOTE:** This is a fork of the original project at https://github.com/jeffreyhorner/Rook
+
+The original maintainer didn't respond to fix various issues which required the package to be removed from CRAN. 
+
+This fork fixes those issues. As a consequence, I ([@evanbiederstedt](https://github.com/evanbiederstedt)) am the new maintainer. 
+
+
+
 Rook: A web server interface for R
 =======================================
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+
+**NOTE:** This is a fork of the original project at https://github.com/jeffreyhorner/Rook
+
+The original maintainer didn't respond to fix various issues which required the package to be removed from CRAN. 
+
+This fork fixes those issues. As a consequence, I ([@evanbiederstedt](https://github.com/evanbiederstedt)) am the new maintainer. 
+
+
 Rook: A web server interface for R
 =======================================
 

--- a/man/Rook-package.Rd
+++ b/man/Rook-package.Rd
@@ -7,7 +7,7 @@ Rook: A web server interface and package for R
 }
 \description{
     This help page defines the Rook specification. It borrows heavily
-    from Ruby's Rack project: \url{http://rack.rubyforge.org/}.
+    from Ruby's Rack project: \url{https://github.com/rack/rack}.
 
     After reading this document, read the \code{\link{Rhttpd}} help file
     as it will get you familiar with installing and running \code{Rook}

--- a/src/rook.c
+++ b/src/rook.c
@@ -51,12 +51,12 @@ SEXP rawmatch( SEXP needle, SEXP haystack, SEXP allMatches){
    return newans;
 }
 
-R_CallMethodDef callMethods[]  = {
+R_CallMethodDef CallEntries[]  = {
    {"rawmatch", (DL_FUNC) &rawmatch, 3},
    {NULL, NULL, 0}
 };
 
-void R_init_Rook(DllInfo *info) {
-   R_registerRoutines(info, NULL, callMethods, NULL, NULL);
+void R_init_Rook(DllInfo *dll) {
+   R_registerRoutines(dll, NULL, CallEntries, NULL, NULL);
    R_useDynamicSymbols(dll, FALSE);
 }

--- a/src/rook.c
+++ b/src/rook.c
@@ -58,5 +58,5 @@ R_CallMethodDef callMethods[]  = {
 
 void R_init_Rook(DllInfo *info) {
    R_registerRoutines(info, NULL, callMethods, NULL, NULL);
-   /*	R_useDynamicSymbols(info, FALSE);*/
+   R_useDynamicSymbols(dll, FALSE);
 }

--- a/src/rook.c
+++ b/src/rook.c
@@ -27,10 +27,15 @@ SEXP rawmatch( SEXP needle, SEXP haystack, SEXP allMatches){
       error_return("all must be a logical vector")
          all = LOGICAL(allMatches)[0];
 
-   if (n2 > n1) return allocVector(INTSXP,0);
+   if (n2 > n1) {
+      SEXP result = PROTECT(allocVector(INTSXP,0));
+      UNPROTECT(1);
+
+      return result;
+   }
 
    k = 0;
-   ans = allocVector(INTSXP, all? (int)(n1 / n2) : 1);
+   ans = PROTECT(allocVector(INTSXP, all? (int)(n1 / n2) : 1));
 
    for (i = 0; i < n1; i++){
       if (x1[i] == x2[0]){
@@ -46,8 +51,10 @@ SEXP rawmatch( SEXP needle, SEXP haystack, SEXP allMatches){
    }
    if (k == LENGTH(ans)) return ans;
 
-   newans = allocVector(INTSXP,k);
+   newans = PROTECT(allocVector(INTSXP,k));
    while(k) {k--;INTEGER(newans)[k] = INTEGER(ans)[k];}
+
+   UNPROTECT(2);
    return newans;
 }
 


### PR DESCRIPTION
Here are the fixes to update the Rook package (version 1.1-1) to be fixed so that the package wasn't removed from CRAN

The new version is Rook: version 1.2